### PR TITLE
Add --help flag support for CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,16 @@ program
   .version('1.0.0')
   .option('-d, --dir <path>', 'Target project directory', '.');
 
+program.on('--help', () => {
+  console.log('');
+  console.log('Examples:');
+  console.log('  $ readme-md-ai --dir .');
+  console.log('  $ npx readme-md-ai --dir ./my-project');
+  console.log('');
+  console.log('📘 Full Docs & Setup Guide:');
+  console.log('👉 https://github.com/its-maneeshk/readme-md-ai');
+});
+
 program.parse();
 const options = program.opts();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "readme-md-ai",
-  "version": "1.0.4",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "readme-md-ai",
-      "version": "1.0.4",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",


### PR DESCRIPTION
This PR adds --help flag using Commander.js, shows usage instructions. Closes #1.